### PR TITLE
Bump whitenoise version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ psycopg2==2.8.3
 pytz==2018.7
 requests==2.21.0
 gunicorn==19.9.0
-whitenoise==4.1.2
+whitenoise==5.0.1


### PR DESCRIPTION
New deployments were throwing the following error:

```
ModuleNotFoundError: No module named 'django.utils.six'
```